### PR TITLE
minor fix(cli): update block explorer link

### DIFF
--- a/cli/src/commands/delegate.rs
+++ b/cli/src/commands/delegate.rs
@@ -512,7 +512,7 @@ impl Delegate {
         eprintln!(
             "\n  {}View operation at: {}/{}",
             emojies::FINGER_POINTER_RIGHT,
-            style("https://delphinet.tezblock.io/transaction").cyan(),
+            style("https://edo2net.tzkt.io").cyan(),
             style(&operation_hash).cyan(),
         );
 

--- a/cli/src/commands/transfer.rs
+++ b/cli/src/commands/transfer.rs
@@ -523,7 +523,7 @@ impl Transfer {
         eprintln!(
             "\n  {}View operation at: {}/{}",
             emojies::FINGER_POINTER_RIGHT,
-            style("https://delphinet.tezblock.io/transaction").cyan(),
+            style("https://edo2net.tzkt.io").cyan(),
             style(&operation_hash).cyan(),
         );
 


### PR DESCRIPTION
update the link returned by the cli to search for the ophash in edo2net instead of delphinet